### PR TITLE
Handle gracefully when device_watts doesn't exist

### DIFF
--- a/src/strava2gpx.py
+++ b/src/strava2gpx.py
@@ -123,7 +123,7 @@ class strava2gpx:
             raise
 
     async def detect_activity_streams(self, activity):
-        if activity['device_watts'] == True:
+        if activity.get('device_watts', False):
             self.streams['watts'] = 1
         else:
             self.streams['watts'] = 0


### PR DESCRIPTION
This small change was necessary for me to write my activities to GPX, since the key `device_watts` did not exist. I haven't looked further into the API for this, but this should be sufficient to keep the same behavior when it does exist.

Thanks for this library, it saved me from needing to write something similar!